### PR TITLE
Updated everything

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,13 @@ Thumbs.db
 .cache/
 Desktop.ini
 .DS_Store
+
+# Node.js dependencies
+node_modules/
+
+# npm
+.npmrc
+package-lock.json
+
+# Heroku deployment
+Procfile

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2018 vanished
+Copyright (c) 2018-2019 vanished
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-worker: node index.js

--- a/README.md
+++ b/README.md
@@ -1,10 +1,18 @@
-# Van [![MIT License](https://img.shields.io/badge/license-MIT-0366d6.svg?longCache=true&style=flat-square)](/LICENSE)
+# VanBot [![MIT License](https://img.shields.io/badge/license-MIT-0366d6.svg?longCache=true&style=flat-square)](/LICENSE) [![Node.js compatibility](https://img.shields.io/badge/node->=8.0.0-026e00.svg?longCache=true&style=flat-square&logo=node.js)](https://nodejs.org/)
 &#x1F440;
+
+VanBot is a Discord bot.
+
+## Commands
+The prefix is `!`.
+
+* `ping` : Get a message from VanBot.
+* `generator` : Generate a sample image of greetings used when a user joins the server.
 
 ## License
 This project is licensed under [MIT License](/LICENSE).
 
-> Copyright (c) 2018 vanished
+> Copyright (c) 2018-2019 vanished
 > 
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal

--- a/index.js
+++ b/index.js
@@ -81,6 +81,15 @@ process.on("uncaughtException", error => {
 .forEach(signal => process.on(signal, () => exit()));
 
 /**
+ * The url module.
+ * @constant {object}
+ * @readonly
+ * @requires module:url
+ * @see {@link https://nodejs.org/api/url.html|URL}
+ */
+const url = require("url");
+
+/**
  * The "prefix". If a message client receives
  * starts with the prefix, it is potentially a command.
  * @constant {string}
@@ -127,15 +136,18 @@ loadFont("./fonts/welcome/discordfont.fnt", font => discordFont = font);
 /**
  * Load a font, retries indefinitely until the font is
  * successfully loaded or the exit sequence has begun.
- * @param {string|String} pathToFont Path to the fnt file to be loaded.
+ * @param {string|String|URL} pathToFont Path to or URL of the fnt file to be loaded.
  * @param {function} callback Callback function with one argument
  * which is an object representing the loaded font.
  * @throws {TypeError} Arguments must match their documented types respectively.
  */
 function loadFont(pathToFont, callback) {
     pathToFont = unboxIfBoxed(pathToFont);
-    if (!(typeof pathToFont === "string" && typeof callback === "function")) {
+    if (!((typeof pathToFont === "string" || pathToFont instanceof url.URL) && typeof callback === "function")) {
         throw new TypeError("Incorrect type(s) for loadFont arguments!");
+    }
+    if (pathToFont instanceof url.URL) {
+        pathToFont = url.format(pathToFont, {unicode: true});
     }
     Jimp.loadFont(pathToFont).then(font => {
         console.log(`Font from path "${pathToFont}" has been loaded.`);
@@ -197,7 +209,7 @@ class PrintData {
 /**
  * Read an image from the given path, print text,
  * and generate buffer of the modified image.
- * @param {string|String} readDestination The path to read original image from.
+ * @param {string|String|URL} readDestination The path or URL to read original image from.
  * @param {...PrintData} printDatas At least one {@link PrintData} containing
  * text to be printed to the image.
  * @returns {Promise<Buffer>} A Promise that resolves to the buffer of
@@ -208,13 +220,14 @@ class PrintData {
  */
 function createImageBuffer(readDestination, ...printDatas) {
     readDestination = unboxIfBoxed(readDestination);
-    if (!(typeof readDestination === "string" && printDatas.length && printDatas.every(printData => printData instanceof PrintData))) {
+    if (!((typeof readDestination === "string" || readDestination instanceof url.URL) && printDatas.length && printDatas.every(printData => printData instanceof PrintData))) {
         throw new TypeError("Incorrect type(s) for createImageBuffer arguments!");
     }
     if (!discordFont) {
         return Promise.reject(new Error("createImageBuffer is called while font has not been loaded yet!"));
     }
-    return Jimp.read(readDestination).then(image => {
+    return Jimp.read(readDestination instanceof url.URL ? url.format(readDestination, {unicode: true}) : readDestination)
+        .then(image => {
             printDatas.forEach(printData => image.print(discordFont, printData.xAxis, printData.yAxis, printData.printString));
             return image.getBufferAsync(Jimp.MIME_PNG);
         });
@@ -338,14 +351,14 @@ function unboxIfBoxed(object) {
 /**
  * Send a greetings image to #greetings channel.
  * @param {Discord.GuildMember} member The member to greet.
- * @param {string|String} background Path to the background image to be used.
+ * @param {string|String|URL} background Path to or URL of the background image to be used.
  * @param {string|String} text The text to greet the member with.
  * @throws {TypeError} Arguments must match their documented types respectively.
  */
 function sendGreetings(member, background, text) {
     background = unboxIfBoxed(background);
     text = unboxIfBoxed(text);
-    if (!(member instanceof Discord.GuildMember && typeof background === "string" && typeof text === "string")) {
+    if (!(member instanceof Discord.GuildMember && (typeof background === "string" || background instanceof url.URL) && typeof text === "string")) {
         throw new TypeError("Incorrect type(s) for sendGreetings arguments!");
     }
     const greetings = "greetings";

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2018 vanished
+ * Copyright (c) 2018-2019 vanished
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,113 +25,391 @@
  * @author vanished
  */
 
-const Discord = require("discord.js");
-const Jimp = require("jimp");
-const ms = require("ms");
+/**
+ * Use strict mode.
+ */
+"use strict";
 
-const client = new Discord.Client();
-const prefix = "!";
-const commonTimeout = ms("3s");
-const commonLeftPadding = 50;
-const commonTopPadding = 250;
-var discordFontPromise;
+/**
+ * The discord.js module.
+ * @constant {object}
+ * @readonly
+ * @requires module:discord.js
+ * @see {@link https://discord.js.org/#/|discord.js}
+ */
+const Discord = requireQuietly("discord.js");
 
-function loadDiscordFont() {
-    discordFontPromise = Jimp.loadFont("./fonts/welcome/discordfont.fnt");
+/**
+ * The jimp module.
+ * @constant {object}
+ * @readonly
+ * @requires module:jimp
+ * @see {@link https://github.com/oliver-moran/jimp|oliver-moran/jimp}
+ */
+const Jimp = requireQuietly("jimp");
+
+if (!(Discord && Jimp)) {
+    process.exitCode = 1;
+    return;
 }
 
-function PrintData(xAxis, yAxis, printString) {
-    if (typeof xAxis !== "number" || typeof yAxis !== "number" || typeof printString !== "string") {
-        throw new TypeError("Incorrect type(s) for PrintData arguments!");
+/**
+ * The client as starting point for VanBot.
+ * @constant {Discord.Client}
+ * @listens Discord.Client#event:ready
+ * @listens Discord.Client#event:guildMemberAdd
+ * @listens Discord.Client#event:guildMemberRemove
+ * @listens Discord.Client#event:message
+ * @readonly
+ */
+const client = new Discord.Client({disableEveryone: true});
+
+/**
+ * An enum for names of events client can listen to.
+ * @constant {object}
+ * @enum {string}
+ * @readonly
+ */
+const Events = Discord.Constants.Events;
+
+process.on("uncaughtException", error => {
+    console.error(error);
+    exit(1);
+}).on("unhandledRejection", console.error);
+
+["SIGHUP", "SIGINT", "SIGTERM", "SIGBREAK"]
+.forEach(signal => process.on(signal, () => exit()));
+
+/**
+ * The "prefix". If a message client receives
+ * starts with the prefix, it is potentially a command.
+ * @constant {string}
+ * @default
+ * @readonly
+ */
+const PREFIX = "!";
+
+/**
+ * The left padding used when generating an image.
+ * @constant {number}
+ * @default
+ * @readonly
+ */
+const COMMON_LEFT_PADDING = 50;
+
+/**
+ * The message used when an image can't be generated.
+ * @constant {string}
+ * @default
+ * @readonly
+ */
+const IMAGE_UNAVAILABLE_MESSAGE = "Sorry, an error occured while generating image.";
+
+/**
+ * An enum for permissions required by the client.
+ * @constant {object}
+ * @enum {number}
+ * @readonly
+ * @see {@link https://discordapp.com/developers/docs/topics/permissions|Permissions}
+ */
+const Permissions = Discord.Permissions.FLAGS;
+
+/**
+ * The font used in generated images. If the font
+ * hasn't been loaded yet, it is undefined.
+ * @type {undefined|Jimp.Font}
+ * @see loadFont
+ */
+let discordFont;
+
+loadFont("./fonts/welcome/discordfont.fnt", font => discordFont = font);
+
+/**
+ * Load a font, retries indefinitely until the font is
+ * successfully loaded or the exit sequence has begun.
+ * @param {string|String} pathToFont Path to the fnt file to be loaded.
+ * @param {function} callback Callback function with one argument
+ * which is an object representing the loaded font.
+ * @throws {TypeError} Arguments must match their documented types respectively.
+ */
+function loadFont(pathToFont, callback) {
+    pathToFont = unboxIfBoxed(pathToFont);
+    if (!(typeof pathToFont === "string" && typeof callback === "function")) {
+        throw new TypeError("Incorrect type(s) for loadFont arguments!");
     }
-    this.xAxis = xAxis;
-    this.yAxis = yAxis;
-    this.printString = printString;
-}
-
-function createPrintedImage(readDestination, writeDestination, ...printDatas) {
-    if (typeof readDestination !== "string" || typeof writeDestination !== "string") {
-        throw new TypeError("Incorrect type(s) for createPrintedImage arguments!");
-    }
-    Jimp.read(readDestination).then(image => {
-        return discordFontPromise.then(font => {
-            for (const printData of printDatas) {
-                if (!(printData instanceof PrintData)) {
-                    throw new TypeError("Arguments of rest parameters of function createPrintedImage must be instances of PrintData!");
-                }
-                image.print(font, printData.xAxis, printData.yAxis, printData.printString);
-            }
-            image.write(writeDestination);
-        }, error => {
-            console.error(`Failed to load font, retrying...\nError: ${error}`);
-            loadDiscordFont();
-        });
-    }, err => console.error(err));
-}
-
-client.on("ready", () => { 
-    console.log(`Logged in as ${client.user.tag}!`);
-    client.user.setPresence({
-        afk: false,
-        status: "online",
-        game: { 
-            name: "everything.", 
-            type: "WATCHING",
-            url: "https://www.twitch.tv/"
+    Jimp.loadFont(pathToFont).then(font => {
+        console.log(`Font from path "${pathToFont}" has been loaded.`);
+        callback(font);
+    }).catch(() => {
+        if (!process.env.EXITING) {
+            loadFont(pathToFont, callback);
         }
     });
-    loadDiscordFont();
-}).on("guildMemberAdd", member => {
-    const channel = member.guild.channels.find("name", "greetings");
-    if (channel === undefined) { // Can't find greetings channel
-        console.error(`No channel is named "greetings" in guild ${guild.name}!`);
+}
+
+/**
+ * Class representing some text to be printed
+ * to images at a specific position.
+ */
+class PrintData {
+
+    /**
+     * Create a new PrintData.
+     * @param {number|Number} xAxis The offset on the X axis.
+     * @param {number|Number} yAxis The offset on the Y axis.
+     * @param {string|String} printString The text to be printed.
+     * @throws {TypeError} Arguments must match their documented types respectively.
+     */
+    constructor(xAxis, yAxis, printString) {
+        xAxis = unboxIfBoxed(xAxis);
+        yAxis = unboxIfBoxed(yAxis);
+        printString = unboxIfBoxed(printString);
+        if (!(typeof xAxis === "number" && typeof yAxis === "number" && typeof printString === "string")) {
+            throw new TypeError("Incorrect type(s) for PrintData arguments!");
+        }
+        if (!(Number.isFinite(xAxis) && Number.isFinite(yAxis))) {
+            throw new RangeError("PrintData arguments \"xAxis\" and \"yAxis\" must not be NaN or infinite!");
+        }
+        this.xAxis = xAxis;
+        this.yAxis = yAxis;
+        this.printString = printString;
+    }
+
+    /**
+     * Get the text to be printed.
+     * @override
+     * @returns The text to be printed.
+     */
+    toString() {
+        return this.printString;
+    }
+
+    /**
+     * Get the text to be printed.
+     * @override
+     * @returns The text to be printed.
+     */
+    valueOf() {
+        return this.printString;
+    }
+}
+
+/**
+ * Read an image from the given path, print text,
+ * and generate buffer of the modified image.
+ * @param {string|String} readDestination The path to read original image from.
+ * @param {...PrintData} printDatas At least one {@link PrintData} containing
+ * text to be printed to the image.
+ * @returns {Promise<Buffer>} A Promise that resolves to the buffer of
+ * the modified image. Rejects with an Error if one or more unexpected
+ * situations is encountered, for example font hasn't been loaded,
+ * or original image can't be read.
+ * @throws {TypeError} Arguments must match their documented types respectively.
+ */
+function createImageBuffer(readDestination, ...printDatas) {
+    readDestination = unboxIfBoxed(readDestination);
+    if (!(typeof readDestination === "string" && printDatas.length && printDatas.every(printData => printData instanceof PrintData))) {
+        throw new TypeError("Incorrect type(s) for createImageBuffer arguments!");
+    }
+    if (!discordFont) {
+        return Promise.reject(new Error("createImageBuffer is called while font has not been loaded yet!"));
+    }
+    return Jimp.read(readDestination).then(image => {
+            printDatas.forEach(printData => image.print(discordFont, printData.xAxis, printData.yAxis, printData.printString));
+            return image.getBufferAsync(Jimp.MIME_PNG);
+        });
+}
+
+/**
+ * Get the offset on the Y axis for text to be printed,
+ * depending on the row it is on in the image.
+ * @param {number|Number} row The row the text is to be on in
+ * the image. This argument is 0-based.
+ * @returns {number} The calculated offset on the Y axis.
+ * @throws {TypeError} Argument must match its documented type.
+ * @throws {RangeError} Argument "row" must be an integer not less than 0.
+ */
+function getYPadding(row) {
+    row = unboxIfBoxed(row);
+    if (typeof row !== "number") {
+        throw new TypeError("Incorrect type for getYPadding argument!");
+    }
+    if (!Number.isInteger(row)) {
+        throw new Error("getYPadding argument \"row\" must be an integer!");
+    }
+    if (row < 0) {
+        throw new RangeError("getYPadding argument \"row\" must be at least 0!");
+    }
+    return 250 + 130 * row;
+}
+
+/**
+ * Check if client has permission in a channel.
+ * @param {Discord.GuildChannel} channel The channel to check for client's permissions.
+ * @param {...string|String|number|Number|Discord.Permissions} permissions At least one
+ * permission to check for if client has in the given channel.
+ * @returns {boolean} "true" if client has all of the permissions
+ * checked for in the given channel or if client has the
+ * {@link Permissions.ADMINISTRATOR} permission, otherwise "false".
+ * @throws {TypeError} Arguments must match their documented types respectively.
+ */
+function clientHasPermissionInChannel(channel, ...permissions) {
+    permissions = permissions.map(unboxIfBoxed);
+    if (!((channel instanceof Discord.GuildChannel) && permissions.length && permissions.every(permission =>
+        typeof permission === "string" || Number.isInteger(permission) ||
+        permission instanceof Discord.Permissions))) {
+        throw new TypeError("Incorrect type(s) for clientHasPermissionInChannel arguments!");
+    }
+    return channel.permissionsFor(client.user).has(permissions);
+}
+
+/**
+ * Destroy the client and set the specified exit code
+ * to stop the process gracefully.
+ * If an error of WebSocket connection was encountered,
+ * client's status isn't set and client isn't destroyed.
+ * @param {number|Number} [exitCode=0] Optional, the exit code
+ * to use when the process exits.
+ * @throws {TypeError} Argument must match its documented type.
+ * @throws {Error} Argument "exitCode" must be an integer.
+ */
+function exit(exitCode) {
+    exitCode = unboxIfBoxed(exitCode);
+    if (!(typeof exitCode === "number" || exitCode == null)) {
+        throw new TypeError("Incorrect type for exit argument!");
+    }
+    if (exitCode != null && !Number.isInteger(exitCode)) {
+        throw new Error("exit argument \"exitCode\" must be an integer!");
+    }
+    if (process.env.EXITING) {
+        return console.log("exit is called but it was already called previously.");
+    }
+    process.env.EXITING = "true";
+    if (exitCode == null) {
+        exitCode = 0;
+    }
+    if (!process.env.WEBSOCKET_DIED) {
+        client.destroy().then(() => console.log("Client has logged out."));
+        console.log("About to set process exit code, process will exit when no more tasks are pending.");
+        process.exitCode = exitCode;
         return;
     }
-    const outFilePath = "./images/welcome/welcome.png";
+    process.exit(exitCode);
+}
 
-    createPrintedImage("./images/welcome/wbg.png",
-        outFilePath,
-        new PrintData(commonLeftPadding, commonTopPadding, member.user.tag),
-        new PrintData(commonLeftPadding, commonTopPadding + 130, `You are the ${channel.guild.memberCount}th member!`));
-
-    setTimeout(() => channel.sendFile(outFilePath), commonTimeout);
-}).on("guildMemberRemove", member => {		
-    const channel = member.guild.channels.find("name", "greetings");
-    if (channel === undefined) { // Can't find greetings channel
-        console.error(`No channel is named "greetings" in guild ${guild.name}!`);
+/**
+ * Load a package without creating any uncaught exceptions.
+ * Errors caught are printed to stderr.
+ * @param {string|String} packageName The name of package to load.
+ * @returns {undefined|object} The loaded package. "undefined" is
+ * returned if either packageName isn't a string or String object,
+ * or package can't be loaded.
+ */
+function requireQuietly(packageName) {
+    packageName = unboxIfBoxed(packageName);
+    if (typeof packageName !== "string") {
         return;
     }
-    const outFilePath = "./images/welcome/goodbye.png";
+    let required;
+    try {
+        required = require(packageName);
+    } catch (error) {
+        console.error(error);
+    }
+    return required;
+}
 
-    createPrintedImage("./images/welcome/bbg.png",
-        outFilePath,
-        new PrintData(commonLeftPadding, commonTopPadding, member.user.tag),
-        new PrintData(commonLeftPadding, commonTopPadding + 130, "We hope to see you soon!"));
+/**
+ * Unbox Number, Boolean and String objects.
+ * @param {} object The object to be unboxed. If it isn't
+ * an instance of Number, Boolean, or String, the original
+ * object or value is returned.
+ * @returns {} Value of unboxed Numbers, Booleans, or Strings.
+ * The original object or value is returned if it isn't
+ * an instance of Number, Boolean, or String.
+ */
+function unboxIfBoxed(object) {
+    if (object instanceof Number || object instanceof Boolean || object instanceof String) {
+        return object.valueOf();
+    }
+    return object;
+}
 
-    setTimeout(() => channel.sendFile(outFilePath), commonTimeout);
-}).on("message", msg => {
-    const content = msg.content;
-    if (!content.startsWith(prefix)) {
+/**
+ * Send a greetings image to #greetings channel.
+ * @param {Discord.GuildMember} member The member to greet.
+ * @param {string|String} background Path to the background image to be used.
+ * @param {string|String} text The text to greet the member with.
+ * @throws {TypeError} Arguments must match their documented types respectively.
+ */
+function sendGreetings(member, background, text) {
+    background = unboxIfBoxed(background);
+    text = unboxIfBoxed(text);
+    if (!(member instanceof Discord.GuildMember && typeof background === "string" && typeof text === "string")) {
+        throw new TypeError("Incorrect type(s) for sendGreetings arguments!");
+    }
+    const greetings = "greetings";
+    const guild = member.guild;
+    if (!guild.available) {
+        return console.log("Guild is unavailable, greetings can't be sent!");
+    }
+    const channel = guild.channels.find(channel => channel.name === greetings && channel.type === "text");
+    if (!channel) {
+        return console.log(`No channel is named ${greetings} in guild ${guild.name}!`);
+    }
+    if (!clientHasPermissionInChannel(channel, Permissions.SEND_MESSAGES, Permissions.ATTACH_FILES)) {
+        return console.log(`Client doesn't have permission "Attach Files" in channel ${greetings}!`);
+    }
+    createImageBuffer(background,
+        new PrintData(COMMON_LEFT_PADDING, getYPadding(0), member.user.tag),
+        new PrintData(COMMON_LEFT_PADDING, getYPadding(1), text))
+    .then(buffer => channel.send(new Discord.Attachment(buffer)).catch(console.error))
+    .catch(error => {
+        console.error(error);
+        channel.send(IMAGE_UNAVAILABLE_MESSAGE).catch(console.error);
+    });
+}
+
+client.once(Events.READY, () => {
+    const clientUser = client.user;
+    console.log(`Logged in as ${clientUser.tag}!`);
+    clientUser.setActivity("everything.", {type: "WATCHING"}).catch(console.error);
+}).on(Events.GUILD_MEMBER_ADD, member =>
+    sendGreetings(member, "./images/welcome/wbg.png", `You are the ${member.guild.memberCount}th member!`)
+).on(Events.GUILD_MEMBER_REMOVE, member =>
+    sendGreetings(member, "./images/welcome/bbg.png", "We hope to see you soon!")
+).on(Events.MESSAGE_CREATE, message => {
+    const content = message.content;
+    const channel = message.channel;
+    if (message.author.bot || !(channel.type === "text" && content.startsWith(PREFIX) && clientHasPermissionInChannel(channel, Permissions.SEND_MESSAGES))) {
         return;
     }
-    switch (content.substring(prefix.length).toLowerCase()) {
+    switch (content.substring(PREFIX.length).toLowerCase().split(/\s+/gi)[0]) {
         case "ping": {
-            msg.reply("Pong!");
+            message.reply("Pong!").catch(console.error);
             break;
         }
         case "generator": {
-            const outFilePath = "./images/welcome/goodbye.png";
-
-            createPrintedImage("./images/welcome/bbg.png",
-                outFilePath,
-                new PrintData(commonLeftPadding, commonTopPadding, "noob#0000"),
-                new PrintData(commonLeftPadding, commonTopPadding + 130, `You are the ${msg.guild.memberCount}th member!`));
-
-            setTimeout(() => msg.channel.sendFile(outFilePath), commonTimeout);
-            break;
-        }
-        default: {
-            // Unknown command, ignores
+            if (!clientHasPermissionInChannel(channel, Permissions.ATTACH_FILES)) {
+                message.reply("Permission \"Attach Files\" is needed to send images!")
+                .catch(console.error);
+                return console.log(`Client doesn't have permission "Attach Files" in channel ${channel.name}!`);
+            }
+            createImageBuffer("./images/welcome/wbg.png",
+                new PrintData(COMMON_LEFT_PADDING, getYPadding(0), "noob#0000"),
+                new PrintData(COMMON_LEFT_PADDING, getYPadding(1), `You are the ${message.guild.memberCount}th member!`))
+            .then(buffer => channel.send(new Discord.Attachment(buffer)).catch(console.error))
+            .catch(error => {
+                console.error(error);
+                channel.send(IMAGE_UNAVAILABLE_MESSAGE).catch(console.error);
+            });
         }
     }
-}).login(process.env.BOT_TOKEN);
+}).on(Events.ERROR, error => {
+    process.env.WEBSOCKET_DIED = "true";
+    console.error(error);
+    exit(1);
+}).login(process.env.BOT_TOKEN).catch(error => {
+    console.error(error);
+    exit();
+});

--- a/package.json
+++ b/package.json
@@ -1,15 +1,46 @@
 {
-  "name": "Van",
-  "description": ":eyes:",
+  "name": "vanbot",
   "version": "0.0.1",
-  "main": "index.js",
-  "scripts": {
-    "start": "node index.js"
+  "description": ":eyes:",
+  "keywords": [
+    "discord",
+    "discord.js",
+    "bot",
+    "van",
+    "vanbot",
+    "JavaScript",
+    "js"
+  ],
+  "homepage": "https://github.com/vanishedvan/vanbot",
+  "bugs": {
+    "url": "https://github.com/vanishedvan/vanbot/issues"
   },
   "license": "MIT",
+  "author": {
+    "name": "vanishedvan",
+    "url": "https://github.com/vanishedvan"
+  },
+  "contributors": [
+    {
+      "name": "LightWayUp",
+      "email": "lightwayuplightwayup@gmail.com",
+      "url": "https://lightwayup.github.io/"
+    }
+  ],
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vanishedvan/vanbot.git"
+  },
+  "scripts": {
+    "start": "node --throw-deprecation index.js",
+    "test": "echo \"No test to run\" && exit 0"
+  },
   "dependencies": {
-    "discord.js": "11.4.2",
-    "jimp": "0.5.6",
-    "ms": "2.1.1"
+    "discord.js": "^11.4.2",
+    "jimp": "^0.6.0"
+  },
+  "engines": {
+    "node": ">=8.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "discord.js": "^11.4.2",
-    "jimp": "^0.6.0"
+    "jimp": "^0.6.1"
   },
   "engines": {
     "node": ">=8.0.0"


### PR DESCRIPTION
- Updated .gitignore to exclude Node.js dependencies, npm files like .npmrc and package-lock.json, and Procfile used for Heroku deployment
- Updated license year information everywhere
- Reorganized package.json to arrange fields in the order they appear on npm package.json documentation page (https://docs.npmjs.com/files/package.json)
- Renamed package name from Van to vanbot, to comply with npm package naming rule and to avoid confusion with the newer van (https://github.com/vanishedvan/van)
- Added keywords field with 7 keywords in package.json
- Added homepage field in package.json to link to GitHub repository page
- Added bugs field in package.json to link to GitHub repository issues page
- Added authors field in package.json
- Added contributors field in package.json
- Added repository field in package.json
- Changed start script to make Node.js throw Error if deprecated APIs are used, smaller projects like this shouldn't face much trouble keeping the code updated
- Added the essential "test script"
- Updated discord.js from `11.4.2` to `^11.4.2`
- Updated jimp from `0.5.6` to `^0.6.1`
- Removed dependency ms as it's no longer used in the project
- Added engines field, node version should be >= 8.0.0
- Deleted Procfile as it's used for deployment and is unrelated to the project
- Added Node.js compatibility badge to README.md
- Added a brief description about the project in README.md
- Added Commands section for commands listing and prefix information in README.md
- Added documentation everywhere in index.js
- Used strict mode
- Added function `requrieQuietly()` to wrap around `require()` function with try-catch block, this allows all missing dependencies to be logged
- Added `ClientOption` when constructing client, with `disableEveryone` enabled
- Added `Events` enum, this reduces hardcoded event names in the code making it less error prone
- Added listener of event `uncaughtException` for process to shut down the process cleanly with exit code 1 when an exception isn't caught
- Added listener of event `unhandledRejection` for process to log th error when a Promise rejects. In the future without handling this event Node.js would exit abruptly with exit code 1
- Added listeners of event `SIGHUP`, `SIGINT`, `SIGTERM`, and `SIGBREAK` to shut down the process cleanly
- Followed JavaScript naming convention much more closely
- Removed `commonTimeout` as it's no longer necessary, images are sent only after they're generated
- Removed `commonTopPadding` as top paddings are now dynamically calculated depending on the row of text
- Removed `discordFontPromise`, added `discordFont` which is set after the font has been loaded
- Added `IMAGE_UNAVAILABLE_MESSAGE` to be sent when an image can't be generated
- Added `Permissions` enum
- Removed unnecessary function `loadDiscordFont()`, added a more versatile `loadFont()` function to continuously retry until the font is loaded, or until the process is exiting
- Rewrote original `PrintData` class with ES6 class syntax
- Accepted boxed wrapper types for constructor of `PrintData` class, they're unboxed with function `unboxIfBoxed()`
- Added validation for `PrintData` constructor arguments, `xAxis` and `yAxis` must be finite and must not be NaN
- Overridden `toString()` and `valueOf()` function of class `PrintData`, both return the text to be printed
- Removed function `createPrintedImage()` due to multiple design flows made in previous commits
- Added function `createImageBuffer()`, a Promise resolving to buffer of the generated image is returned
- Accepted boxed wrapper types for `createImageBuffer()`, they're unboxed with function `unboxIfBoxed()`
- Replaced for loops with the more functional approach `forEach()`
- Added function `getYPadding()` to calculate vertical text position
- Added function `clientHasPermissionInChannel()` to check client's permission for actions such as sending messages and attaching files
- Added function `exit()` to shut down the process gracefully
- Added function `unboxIfBoxed()` to unbox wrapper types - String, Number and Boolean
- Added helper function `sendGreetings()` to send image to greetings channel on user join and member leave. This greatly helps reduction in repetitive code, making it a lot less error prone
- Used `once()` instead of `on()` for listening to ready event, as it seems to fire only once
- Replaced call to `setPresence()` with `setActivity()` as most values are set by default and are set to expected values
- Added checks for certain criteria for response when a message is received - the author must not be a bot, the channel must not be a `DMChannel`, and client must be able to send messages
- Ignored additional arguments added after commands
- Added `catch()` to Promise returned from `message.reply()`, Promise rejections should always be handled
- Added check for client's ability to attach images when generator command is used. If lacking permission, a warning message is sent to the channel
- Removed hacky and broken delay of image sending achieved with `setTimeout()`, images are now only sent after they're generated
- Removed default case in switch as it was ignored and did nothing
- Added listener of error event emitted by the client to prevent Node.js from crashing abruptly
- Added `catch()` to Promise returned from `client.login()` to shut down the process cleanly on login failure
- A whole lot of other miscellaneous improvements and refinements throughout the code